### PR TITLE
feature/axios-utils

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import * as authConfig from "./auth.config";
 import * as authService from "./auth.service";
 import * as userService from "../user/user.service";
 // Utils
-import { generateRandomString } from "../../utils";
+import * as utils from "../../utils";
 
 export const getMe = async (req: Request, res: Response, _next: NextFunction) => {
 	const user = req.session.user;
@@ -15,7 +15,7 @@ export const getMe = async (req: Request, res: Response, _next: NextFunction) =>
 };
 
 export const login = async (req: Request, res: Response, _next: NextFunction) => {
-	const state = generateRandomString(16);
+	const state = utils.generateRandomString(16);
 	const scope = authConfig.scopes.join(" ");
 
 	res.cookie(authConfig.STATE_KEY, state);
@@ -48,16 +48,7 @@ export const authCallback = async (req: Request, res: Response, _next: NextFunct
 
 	res.clearCookie(authConfig.STATE_KEY);
 
-	const config = {
-		headers: {
-			Accept: "application/json",
-			"Content-Type": "application/x-www-form-urlencoded",
-		},
-		auth: {
-			username: process.env.SPOTIFY_CLIENT_ID,
-			password: process.env.SPOTIFY_CLIENT_SECRET,
-		},
-	};
+	const config = utils.getAxiosConfig({ withSpotifyAuth: true, urlEncoded: true });
 
 	const data = new URLSearchParams({
 		grant_type: "authorization_code",

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,13 +1,11 @@
 import axios from "axios";
 // Adapter
 import * as authAdapter from "./auth.adapters";
+// Utils
+import * as utils from "../../utils";
 
 export const getUserFromSpotify = async (accessToken: string) => {
-	const config = {
-		headers: {
-			Authorization: `Bearer ${accessToken}`,
-		},
-	};
+	const config = utils.getAxiosConfig({ accessToken });
 
 	const { data } = await axios.get("https://api.spotify.com/v1/me", config);
 	return authAdapter.adaptUserFromSpotify(data);

--- a/src/modules/song/song.service.ts
+++ b/src/modules/song/song.service.ts
@@ -5,6 +5,8 @@ import { AppDataSource } from "../../data-source";
 import { Song, NewSongEntry } from "../../models";
 // Adapter
 import * as songAdapter from "./song.adapter";
+// Utils
+import * as utils from "../../utils";
 
 const songRepository = AppDataSource.getRepository(Song);
 
@@ -29,11 +31,7 @@ export const createSong = async (song: NewSongEntry) => {
 };
 
 export const getSongFromSpotify = async (accessToken: string, id: string) => {
-	const config = {
-		headers: {
-			Authorization: `Bearer ${accessToken}`,
-		},
-	};
+	const config = utils.getAxiosConfig({ accessToken });
 
 	const { data } = await axios.get(`https://api.spotify.com/v1/tracks/${id}`, config);
 	return songAdapter.adaptSongFromSpotify(data);

--- a/src/utils/axios.utils.ts
+++ b/src/utils/axios.utils.ts
@@ -1,0 +1,28 @@
+import { AxiosRequestConfig } from "axios";
+
+type PropsAxiosConfig = {
+	withSpotifyAuth?: boolean;
+	accessToken?: string;
+	urlEncoded?: boolean;
+};
+
+export const getAxiosConfig = ({
+	withSpotifyAuth,
+	accessToken,
+	urlEncoded,
+}: PropsAxiosConfig): AxiosRequestConfig<URLSearchParams> => {
+	const Authorization = accessToken ? `Bearer ${accessToken}` : undefined;
+	const auth = withSpotifyAuth && {
+		username: process.env.SPOTIFY_CLIENT_ID,
+		password: process.env.SPOTIFY_CLIENT_SECRET,
+	};
+	const headers = {
+		"Content-Type": urlEncoded ? "application/x-www-form-urlencoded" : "application/json",
+		Authorization,
+	};
+
+	return {
+		headers,
+		auth,
+	};
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from "./axios.utils";
 export * from "./random.utils";


### PR DESCRIPTION
### Pull request details:

- Add axios utils to get request configuration.

#### getAxiosConfig

Return axios configuration object based on the passed parameters.

```ts
type PropsAxiosConfig = {
  withSpotifyAuth?: boolean;
  accessToken?: string;
  urlEncoded?: boolean;
};
const = getAxiosConfig({
  withSpotifyAuth,
  accessToken,
  urlEncoded
}: PropsAxiosConfig): AxiosRequestConfig<URLSearchParams> => { ... }

```
if `withSpotifyAuth` is set to true the axios configuration object will include an `auth `object with Spotify credentials obtained through environment variables.
if the object passed as prop includes the accessToken the function will add the Authorization prop to the config object.
If `urlEconded` is set to true the `Content-Type` will change from `"application/json"` to `"application/x-www-form-urlencoded"`.