### PR TITLE
feature: Add refresh access token route and function

### DIFF
--- a/src/modules/auth/auth.routes.ts
+++ b/src/modules/auth/auth.routes.ts
@@ -8,5 +8,6 @@ router.get("/login", authController.login);
 router.get("/callback", authController.authCallback);
 router.get("/me", authController.getMe);
 router.get("/logout", authController.logout);
+router.get("/refresh", authController.refresh);
 
 export default router;


### PR DESCRIPTION
### Pull request details:

- Add refresh function to auth controller.
- Add refresh route to auth routes.

### New endpoint added:

#### GET - /api/auth/refresh

Use the refresh token stored in the express session to refresh the potify access token.